### PR TITLE
Update valve grammar to reflect valve.py

### DIFF
--- a/valve_grammar.ne
+++ b/valve_grammar.ne
@@ -41,7 +41,7 @@ arguments -> argument ("," _ argument):* {%
 
 argument -> field | named_arg | label | int | function
 
-field -> label "." label {% function(d) {
+field -> label "." str {% function(d) {
   return {
     type: "field",
     table: d[0][0],
@@ -62,8 +62,10 @@ datatype -> label {%
       name: d[0][0],
     } } %}
 
+str -> TEXT | dqstring {% id %}
 label -> WORD | dqstring {% id %}
 int -> INTEGER {% parseInt %}
 
 INTEGER -> [0-9]:+ {% join %}
-WORD -> [a-zA-Z ]:+ {% join %}
+WORD -> [a-zA-Z-_]:+ {% join %}
+TEXT -> [a-zA-Z-_ ]:+ {% join %}

--- a/valve_grammar.ne
+++ b/valve_grammar.ne
@@ -39,13 +39,20 @@ arguments -> argument ("," _ argument):* {%
     return flatten(d).filter(item => item && item != ",");
   } %}
 
-argument -> field | label | integer | function
+argument -> field | named_arg | label | int | function
 
 field -> label "." label {% function(d) {
   return {
     type: "field",
     table: d[0][0],
     column: d[2][0],
+  }}%}
+
+named_arg -> label "=" label {% function(d) {
+  return {
+    type: "named_arg",
+    name: d[0][0],
+    value: d[2][0],
   }}%}
 
 datatype -> label {%
@@ -56,7 +63,7 @@ datatype -> label {%
     } } %}
 
 label -> WORD | dqstring {% id %}
-integer -> INTEGER {% parseInt %}
+int -> INTEGER {% parseInt %}
 
 INTEGER -> [0-9]:+ {% join %}
-WORD -> [a-zA-Z]:+ {% join %}
+WORD -> [a-zA-Z ]:+ {% join %}


### PR DESCRIPTION
This adds `named_arg` to function arguments and renames `integer` to `int` (calling it integer collided with `INTEGER`).

We also need to allow spaces in `label` values, e.g. when table columns have spaces in them.