### PR TITLE
WIP - Allow empty quotes

### DIFF
--- a/valve_grammar.ne
+++ b/valve_grammar.ne
@@ -36,7 +36,7 @@ function_name -> WORD
 
 arguments -> argument ("," _ argument):* {%
   function(d) {
-    return flatten(d).filter(item => item && item != ",");
+    return flatten(d).filter(item => item !== null && item != ",");
   } %}
 
 argument -> field | label | integer | function | named_arg


### PR DESCRIPTION
This fix works for `valve.js`, but if you port it to `valve.py` it still fails:
```
VisitError: Error trying to process rule "alias_0":

TypeError: Undefined and null dont have properties (tried getting property 'join')
```

This seems to be an issue that we need to fix in the `parse.py` script (like the fix in https://github.com/ontodev/valve.py/pull/28), but that doesn't work for auto-generating `parse.py` from `valve_grammar.ne`.

The closest I got to working with both JS and Python resulted in a value `'""'` when we just want `''`.