### PR TITLE
Support more than one regex flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build/actual.txt: build/valve_grammar.js | build
 	nearley-test -q -i 'split(prefix.prefix, "&", foo(bar), CURIE(prefix.prefix))' $< >> $@
 	nearley-test -q -i 'a(b(c(d)))' $< >> $@
 	nearley-test -q -i 'in(with-dash."space column")' $< >> $@
-	nearley-test -q -i 'regex(s/pattern/replacement/g)' $< >> $@
+	nearley-test -q -i 'regex(s/pattern/replacement/gi)' $< >> $@
 	nearley-test -q -i 'regex(s/pat\/ern/replacement/)' $< >> $@
 
 build/valve_grammar.js: valve_grammar.ne | build

--- a/tests/expected.txt
+++ b/tests/expected.txt
@@ -103,7 +103,7 @@
           type: 'regex',
           pattern: 'pattern',
           replace: 'replacement',
-          flags: 'g'
+          flags: 'gi'
         }
       ]
     }

--- a/valve_grammar.ne
+++ b/valve_grammar.ne
@@ -70,7 +70,7 @@ regex_sub -> "s/" regex_pattern "/" regex_pattern "/" regex_flag {%
       type: "regex",
       pattern: d[1][0],
       replace: d[3][0].replace("\\", ""),
-      flags: d[5][0],
+      flags: d[5],
     } } %}
 
 regex_match -> "s/" regex_pattern "/" regex_flag {%
@@ -78,7 +78,7 @@ regex_match -> "s/" regex_pattern "/" regex_flag {%
     return {
       type: "regex",
       pattern: d[1][0],
-      flags: d[3][0],
+      flags: d[3],
     } } %}
 
 regex_pattern -> regex_escaped | regex_unescaped


### PR DESCRIPTION
The current grammar only returns the first regex flag if more than one is provided, e.g.
```
s/pattern/replacement/gi
```

This is a small fix to return all flags. I updated the tests as well to use two flags.