### PR TITLE
Fix test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 test: tests/expected.txt build/actual.txt
 	diff $^
 
+test-no-whitespace: build/expected-min.txt build/actual-min.txt
+	diff -w $^
+
 build:
 	mkdir -p $@
 
@@ -14,12 +17,18 @@ build/actual.txt: build/valve_grammar.js | build
 	nearley-test -q -i 'CURIE(prefix.prefix)' $< >> $@
 	nearley-test -q -i 'CURIE(prefix."xspace prefix")' $< >> $@
 	nearley-test -q -i 'CURIE(named=arg)' $< >> $@
-	nearley-test -q -i 'split(prefix.prefix, "&", foo(bar), CURIE(prefix.prefix))' $< >> $@
-	nearley-test -q -i 'a(b(c(d)))' $< >> $@
+	nearley-test -q -i 'split(prefix.prefix, "&", foo("bar"), CURIE(prefix.prefix))' $< >> $@
+	nearley-test -q -i 'a(b(c("d")))' $< >> $@
 	nearley-test -q -i 'in(with-dash."space column")' $< >> $@
 	nearley-test -q -i 'regex(s/pattern/replacement/gi)' $< >> $@
 	nearley-test -q -i 'regex(s/pat\/ern/replacement/)' $< >> $@
 	nearley-test -q -i 'x(foo, 2, bar2)' $< >> $@
+
+build/actual-min.txt: build/actual.txt
+	cat $< | tr -d '\n' > $@
+
+build/expected-min.txt: tests/expected.txt | build
+	cat $< | tr -d '\n' > $@
 
 build/valve_grammar.js: valve_grammar.ne | build
 	nearleyc $< -o $@

--- a/tests/expected.txt
+++ b/tests/expected.txt
@@ -119,7 +119,7 @@
           type: 'regex',
           pattern: 'pat\\/ern',
           replace: 'replacement',
-          flags: undefined
+          flags: ''
         }
       ]
     }


### PR DESCRIPTION
All strings need to be surrounded with double quotes, so I updated the Makefile to reflect this. 

I also added a task to the Makefile to test ignoring newlines and whitespace between the expected and actual output. If there is a difference, the output isn't super helpful, but it will at least pass even if the formatting is different. This way I can more easily catch issues, rather than trying to manually check the outputs.

I guess `diff -w` doesn't work with newlines, so I'm wondering if there's a better way to do this?

Regex flags was also `undefined` in the expected output, when no flags return an empty string.